### PR TITLE
AO-12: Update documentation to point to Add Ons instead of Modulus

### DIFF
--- a/en/Administering OpenMRS/maintenance.md
+++ b/en/Administering OpenMRS/maintenance.md
@@ -125,7 +125,7 @@ Be sure to test any upgrades on a server other than the primary server you use f
 
 ## Updating modules
 
-Supported community-developed OpenMRS modules are regularly updated, and those new versions are published in the OpenMRS module repository. You should check for upgraded modules regularly. Go to [http://modules.openmrs.org/](http://modules.openmrs.org/) or view the "Manage Modules" page from the OpenMRS **Administration** page. From there, you can upgrade a module with updates automatically by clicking **Install Update**, or you may manually upload the new version by following the instructions on the page.
+Supported community-developed OpenMRS modules are regularly updated, and those new versions are published in the OpenMRS Add-ons index. You should check for upgraded modules regularly. Go to [https://addons.openmrs.org/](https://addons.openmrs.org/) or view the "Manage Modules" page from the OpenMRS **Administration** page. From there, you can upgrade a module with updates automatically by clicking **Install Update**, or you may manually upload the new version by following the instructions on the page.
 
 ## Amani's maintenance plan
 

--- a/en/Appendices/appendix-a-glossary.md
+++ b/en/Appendices/appendix-a-glossary.md
@@ -70,7 +70,7 @@
 
 **module**: A software package that extends OpenMRS functionality in specific ways; often developed by others in the OpenMRS community.
 
-**module repository**: An online resource to find and maintain community-developed OpenMRS add-on modules. [http://modules.openmrs.org/](http://modules.openmrs.org/)
+**module repository**: An online resource to find and maintain community-developed OpenMRS add-on modules. [https://addons.openmrs.org/](https://addons.openmrs.org/)
 
 **observation**: One piece of information that is recorded about a person at a moment in time.
 
@@ -141,4 +141,3 @@
 **wiki**: A web site containing documentation and other resources for a project or organization.
 
 **workflow**: A series of tasks to accomplish a goal.
-

--- a/en/Configuration/customizing-openmrs-with-plug-in-modules.md
+++ b/en/Configuration/customizing-openmrs-with-plug-in-modules.md
@@ -8,9 +8,9 @@ OpenMRS has a modular architecture, which allows special functionality to be eas
 
 ## Module repository
 
-You can view available modules in the OpenMRS Module Repository:
+You can view available modules in the OpenMRS Add-ons index:
 
-[http://modules.openmrs.org/](http://modules.openmrs.org/)
+[https://addons.openmrs.org/](https://addons.openmrs.org/)
 
 It is a place where you can find published modules. Each module has a page with a description, a link for downloading, and a link to the module's documentation.
 

--- a/en/Planning/identifying-your-needs.md
+++ b/en/Planning/identifying-your-needs.md
@@ -61,7 +61,7 @@ The OpenMRS Form Bank is a new community-driven project that is beginning to col
 
 ### Explore the module repository
 
-Implementers should consult the OpenMRS Module Repository at [http://modules.openmrs.org/](http://modules.openmrs.org/) before considering customization through software development.
+Implementers should consult the OpenMRS Module Repository at [https://addons.openmrs.org/](https://addons.openmrs.org/) before considering customization through software development.
 
 There is a good chance that someone has created a module to address needs you may have. Read the "Customizing OpenMRS with Plug-in Modules" chapter for a list of recommended modules.
 

--- a/en/appendix-a-glossary.md
+++ b/en/appendix-a-glossary.md
@@ -70,7 +70,7 @@
 
 **module**: A software package that extends OpenMRS functionality in specific ways; often developed by others in the OpenMRS community.
 
-**module repository**: An online resource to find and maintain community-developed OpenMRS add-on modules. [http://modules.openmrs.org/](http://modules.openmrs.org/)
+**module repository**: An online resource to find and maintain community-developed OpenMRS add-on modules. [https://addons.openmrs.org/](https://addons.openmrs.org/)
 
 **observation**: One piece of information that is recorded about a person at a moment in time.
 


### PR DESCRIPTION
https://issues.openmrs.org/browse/AO-12

I found https://modules.openmrs.org links which should be updated to https://addons.openmrs.org/ .